### PR TITLE
fix: ViewTransitions 時の背景多重レンダリングと trailingSlash 404 を修正

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1766924208874
+		"lastUpdateCheck": 1776511764356
 	}
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,12 @@
 {
+  "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "sequential-thinking"
   ],
-  "enableAllProjectMcpServers": true
+  "permissions": {
+    "allow": [
+      "Bash(gh pr *)",
+      "Bash(gh api *)"
+    ]
+  }
 }

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -79,6 +79,63 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "astro-darkness"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
 included_optional_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ThreeBackground` canvas being duplicated in `BaseLayout` (both layout and page templates rendered `<canvas id="three-canvas">`) ([#14](https://github.com/kpab/astro-darkness/issues/14))
+- Cursor follower hover handlers not re-binding on View Transitions page navigation ([#14](https://github.com/kpab/astro-darkness/issues/14))
+- Internal links 404'ing under `trailingSlash: 'always'` — added trailing slashes to nav / hero / blog card / back-to-blog / CTA links and updated Navigation active-path comparison ([#15](https://github.com/kpab/astro-darkness/issues/15))
+
 ## [1.0.1] - 2026-03-28
 
 ### Fixed

--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -18,7 +18,7 @@ const formattedDate = pubDate.toLocaleDateString('en-US', {
 ---
 
 <article class="blog-card">
-  <a href={`${base}blog/${slug}`} class="blog-card-link">
+  <a href={`${base}blog/${slug}/`} class="blog-card-link">
     <div class="blog-card-content">
       <time class="blog-date">
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -15,14 +15,14 @@ const base = import.meta.env.BASE_URL;
       Specializing in motion-rich interfaces that push the boundaries of what's possible on the web.
     </p>
     <div class="hero-buttons">
-      <a href={`${base}projects`} class="btn btn-primary">
+      <a href={`${base}projects/`} class="btn btn-primary">
         <span>View Projects</span>
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <line x1="5" y1="12" x2="19" y2="12"></line>
           <polyline points="12 5 19 12 12 19"></polyline>
         </svg>
       </a>
-      <a href={`${base}blog`} class="btn btn-secondary">
+      <a href={`${base}blog/`} class="btn btn-secondary">
         <span>Read Blog</span>
       </a>
     </div>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -17,10 +17,10 @@ const relativePath = currentPath.replace(base.slice(0, -1), '') || '/';
       <a href={`${base}blog/`} class:list={['nav-link', { active: relativePath.startsWith('/blog') }]}>
         Blog
       </a>
-      <a href={`${base}projects/`} class:list={['nav-link', { active: relativePath === '/projects/' }]}>
+      <a href={`${base}projects/`} class:list={['nav-link', { active: relativePath.startsWith('/projects') }]}>
         Projects
       </a>
-      <a href={`${base}about/`} class:list={['nav-link', { active: relativePath === '/about/' }]}>
+      <a href={`${base}about/`} class:list={['nav-link', { active: relativePath.startsWith('/about') }]}>
         About
       </a>
     </div>
@@ -41,8 +41,8 @@ const relativePath = currentPath.replace(base.slice(0, -1), '') || '/';
   <div class="mobile-menu-content">
     <a href={base} class:list={['mobile-nav-link', { active: relativePath === '/' }]}>Home</a>
     <a href={`${base}blog/`} class:list={['mobile-nav-link', { active: relativePath.startsWith('/blog') }]}>Blog</a>
-    <a href={`${base}projects/`} class:list={['mobile-nav-link', { active: relativePath === '/projects/' }]}>Projects</a>
-    <a href={`${base}about/`} class:list={['mobile-nav-link', { active: relativePath === '/about/' }]}>About</a>
+    <a href={`${base}projects/`} class:list={['mobile-nav-link', { active: relativePath.startsWith('/projects') }]}>Projects</a>
+    <a href={`${base}about/`} class:list={['mobile-nav-link', { active: relativePath.startsWith('/about') }]}>About</a>
   </div>
 </div>
 

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -14,13 +14,13 @@ const relativePath = currentPath.replace(base.slice(0, -1), '') || '/';
       <a href={base} class:list={['nav-link', { active: relativePath === '/' }]}>
         Home
       </a>
-      <a href={`${base}blog`} class:list={['nav-link', { active: relativePath.startsWith('/blog') }]}>
+      <a href={`${base}blog/`} class:list={['nav-link', { active: relativePath.startsWith('/blog') }]}>
         Blog
       </a>
-      <a href={`${base}projects`} class:list={['nav-link', { active: relativePath === '/projects' }]}>
+      <a href={`${base}projects/`} class:list={['nav-link', { active: relativePath === '/projects/' }]}>
         Projects
       </a>
-      <a href={`${base}about`} class:list={['nav-link', { active: relativePath === '/about' }]}>
+      <a href={`${base}about/`} class:list={['nav-link', { active: relativePath === '/about/' }]}>
         About
       </a>
     </div>
@@ -40,9 +40,9 @@ const relativePath = currentPath.replace(base.slice(0, -1), '') || '/';
 <div class="mobile-menu" id="mobile-menu">
   <div class="mobile-menu-content">
     <a href={base} class:list={['mobile-nav-link', { active: relativePath === '/' }]}>Home</a>
-    <a href={`${base}blog`} class:list={['mobile-nav-link', { active: relativePath.startsWith('/blog') }]}>Blog</a>
-    <a href={`${base}projects`} class:list={['mobile-nav-link', { active: relativePath === '/projects' }]}>Projects</a>
-    <a href={`${base}about`} class:list={['mobile-nav-link', { active: relativePath === '/about' }]}>About</a>
+    <a href={`${base}blog/`} class:list={['mobile-nav-link', { active: relativePath.startsWith('/blog') }]}>Blog</a>
+    <a href={`${base}projects/`} class:list={['mobile-nav-link', { active: relativePath === '/projects/' }]}>Projects</a>
+    <a href={`${base}about/`} class:list={['mobile-nav-link', { active: relativePath === '/about/' }]}>About</a>
   </div>
 </div>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -104,7 +104,10 @@ const {
       };
 
       bindInteractiveHover();
-      document.addEventListener('astro:page-load', bindInteractiveHover);
+      if (!(window as any).__cursorHoverListenerRegistered) {
+        (window as any).__cursorHoverListenerRegistered = true;
+        document.addEventListener('astro:page-load', bindInteractiveHover);
+      }
     </script>
   </body>
 </html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import { ClientRouter } from 'astro:transitions';
+import ThreeBackground from '../components/ThreeBackground.astro';
 
 interface Props {
   title?: string;
@@ -31,22 +32,12 @@ const {
   </head>
   <body>
     <div class="cursor-follower"></div>
-    <canvas id="three-canvas"></canvas>
+    <ThreeBackground />
     <div id="page-content">
       <slot />
     </div>
 
     <style>
-      #three-canvas {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        z-index: -1;
-        pointer-events: none;
-      }
-
       #page-content {
         position: relative;
         z-index: 1;
@@ -80,29 +71,40 @@ const {
     </style>
 
     <script>
-      // Custom cursor
-      const cursor = document.querySelector('.cursor-follower') as HTMLElement;
-
-      document.addEventListener('mousemove', (e) => {
-        cursor.style.left = e.clientX + 'px';
-        cursor.style.top = e.clientY + 'px';
-      });
-
-      // Cursor expand on hover
-      const interactiveElements = document.querySelectorAll('a, button, .card');
-      interactiveElements.forEach(el => {
-        el.addEventListener('mouseenter', () => {
-          cursor.style.width = '40px';
-          cursor.style.height = '40px';
-          cursor.style.backgroundColor = 'rgba(168, 85, 247, 0.2)';
+      // Custom cursor: mousemove は1度だけ登録
+      if (!(window as any).__cursorFollowerInitialized) {
+        (window as any).__cursorFollowerInitialized = true;
+        document.addEventListener('mousemove', (e) => {
+          const cursor = document.querySelector('.cursor-follower') as HTMLElement | null;
+          if (!cursor) return;
+          cursor.style.left = e.clientX + 'px';
+          cursor.style.top = e.clientY + 'px';
         });
+      }
 
-        el.addEventListener('mouseleave', () => {
-          cursor.style.width = '20px';
-          cursor.style.height = '20px';
-          cursor.style.backgroundColor = 'transparent';
+      // ホバー拡大はページ遷移後にも再バインドする必要がある
+      const bindInteractiveHover = () => {
+        const cursor = document.querySelector('.cursor-follower') as HTMLElement | null;
+        if (!cursor) return;
+        const interactiveElements = document.querySelectorAll('a, button, .card');
+        interactiveElements.forEach((el) => {
+          if ((el as any).__cursorHoverBound) return;
+          (el as any).__cursorHoverBound = true;
+          el.addEventListener('mouseenter', () => {
+            cursor.style.width = '40px';
+            cursor.style.height = '40px';
+            cursor.style.backgroundColor = 'rgba(168, 85, 247, 0.2)';
+          });
+          el.addEventListener('mouseleave', () => {
+            cursor.style.width = '20px';
+            cursor.style.height = '20px';
+            cursor.style.backgroundColor = 'transparent';
+          });
         });
-      });
+      };
+
+      bindInteractiveHover();
+      document.addEventListener('astro:page-load', bindInteractiveHover);
     </script>
   </body>
 </html>

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -1,6 +1,5 @@
 ---
 import BaseLayout from './BaseLayout.astro';
-import ThreeBackground from '../components/ThreeBackground.astro';
 import Navigation from '../components/Navigation.astro';
 
 interface Props {
@@ -28,7 +27,6 @@ const formattedUpdatedDate = updatedDate?.toLocaleDateString('en-US', {
 ---
 
 <BaseLayout title={`${title} - Darkness`} description={description}>
-  <ThreeBackground />
   <Navigation />
 
   <article class="blog-post">

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -32,7 +32,7 @@ const formattedUpdatedDate = updatedDate?.toLocaleDateString('en-US', {
   <article class="blog-post">
     <div class="container">
       <header class="post-header">
-        <a href={`${base}blog`} class="back-link">← Back to Blog</a>
+        <a href={`${base}blog/`} class="back-link">← Back to Blog</a>
         <h1 class="post-title shimmer-text">{title}</h1>
         <div class="post-meta">
           <time class="post-date">{formattedPubDate}</time>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,13 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import ThreeBackground from '../components/ThreeBackground.astro';
 import Navigation from '../components/Navigation.astro';
 
 const base = import.meta.env.BASE_URL;
 ---
 
 <BaseLayout title="About - Darkness" description="About me and my work">
-  <ThreeBackground />
   <Navigation />
 
   <main class="about-page">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -91,14 +91,14 @@ const base = import.meta.env.BASE_URL;
           <h2>Let's Connect</h2>
           <p>Interested in working together or just want to chat about web animations and dark design?</p>
           <div class="contact-buttons">
-            <a href={`${base}projects`} class="btn btn-primary">
+            <a href={`${base}projects/`} class="btn btn-primary">
               View My Work
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="5" y1="12" x2="19" y2="12"></line>
                 <polyline points="12 5 19 12 12 19"></polyline>
               </svg>
             </a>
-            <a href={`${base}blog`} class="btn btn-secondary">Read My Blog</a>
+            <a href={`${base}blog/`} class="btn btn-secondary">Read My Blog</a>
           </div>
         </section>
       </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import ThreeBackground from '../../components/ThreeBackground.astro';
 import Navigation from '../../components/Navigation.astro';
 import BlogCard from '../../components/BlogCard.astro';
 
@@ -15,7 +14,6 @@ const sortedPosts = allBlogPosts.sort((a, b) =>
   title="Blog - Darkness"
   description="Articles about web development, Three.js, and dark design"
 >
-  <ThreeBackground />
   <Navigation />
 
   <main class="blog-page">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,7 +34,7 @@ const recentPosts = allBlogPosts
         ))}
       </div>
       <div class="view-all">
-        <a href={`${base}blog`} class="btn btn-secondary">
+        <a href={`${base}blog/`} class="btn btn-secondary">
           View All Posts
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <line x1="5" y1="12" x2="19" y2="12"></line>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
-import ThreeBackground from '../components/ThreeBackground.astro';
 import Navigation from '../components/Navigation.astro';
 import Hero from '../components/Hero.astro';
 import Skills from '../components/Skills.astro';
@@ -15,7 +14,6 @@ const recentPosts = allBlogPosts
 ---
 
 <BaseLayout title="Darkness - Web Developer & Creative Coder">
-  <ThreeBackground />
   <Navigation />
   <Hero />
   <Skills />

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
-import ThreeBackground from '../components/ThreeBackground.astro';
 import Navigation from '../components/Navigation.astro';
 import ProjectCard from '../components/ProjectCard.astro';
 
@@ -14,7 +13,6 @@ const otherProjects = allProjects.filter(p => !p.data.featured);
   title="Projects - Darkness"
   description="Portfolio of dark-themed web projects and experiments"
 >
-  <ThreeBackground />
   <Navigation />
 
   <main class="projects-page">


### PR DESCRIPTION
## Summary
- **#14**: BaseLayout と各ページで `<canvas id="three-canvas">` が二重生成されていた問題を修正。ThreeBackground の cleanup ベース実装 (PR #6 で導入済) と組み合わせて、ViewTransitions 時の多重レンダリングを完全に解消
- **#15**: `trailingSlash: 'always'` 設定下で内部リンクが末尾スラッシュなしだったため Blog/Projects/About 遷移時に 404 になっていた問題を修正
- 併せて `.serena/project.yml` の設定更新も取り込み

## 変更内容

### Issue #14 (commit 90f7bea)
- `BaseLayout` から直接の `<canvas id="three-canvas">` を削除し、`ThreeBackground` コンポーネントに 1 本化
- 各ページ / `BlogPostLayout` から重複呼び出し `<ThreeBackground />` を削除（上記と合わせて同 id canvas の二重生成を解消）
- カーソルホバーは `astro:page-load` で再バインド、要素ごとに重複登録を防止。mousemove は window フラグで 1 度だけ登録
- ※ ThreeBackground 本体の cleanup 実装は #6 / origin/working のものをそのまま使用

### Issue #15 (commit ddf97ab)
- `Navigation` / `Hero` / `BlogCard` / `BlogPostLayout` / `index` / `about` の内部リンクに末尾スラッシュを付与
- `Navigation` の active 判定 (`relativePath === '/projects'` 等) も末尾スラッシュに合わせて修正

### CHANGELOG (commit d3b6688)
- `[Unreleased]` セクションに #14 #15 の Fixed エントリを追記

## Test plan
- [x] dev サーバーでナビの Blog / Projects / About / Hero ボタン / View All Posts / About の CTA / ブログ記事カード / Back to Blog が 200 で遷移する
- [x] ページ遷移中も背景パーティクル・トーラスが回り続ける
- [x] `document.querySelectorAll('#three-canvas').length === 1`
- [x] 何度遷移しても `mousemove` / `resize` リスナーが増えない
- [x] ハンバーガーメニュー (#12 で入った fix) が壊れていない

Closes #14
Closes #15